### PR TITLE
Use of CUDA_VISIBLE_DEVICES to get NGPUS

### DIFF
--- a/kblas-test-l2.sh
+++ b/kblas-test-l2.sh
@@ -12,8 +12,15 @@ STOP_DIM=16500
 STEP_DIM=128
 #--------------------
 GPU=0
-NGPUS=$(nvidia-smi -L | wc -l)
 NGPU1=2
+if [ -z $CUDA_VISIBLE_DEVICES ]; then
+  NGPUS=$(nvidia-smi -L | wc -l)
+else
+  aux=${CUDA_VISIBLE_DEVICES/,,/,} # replace double commas
+  aux=${aux/%,/} # remove trailing comma
+  aux=${aux/#,/} # remove leading comma
+  NGPUS=$(echo "$aux," |  awk 'BEGIN{FS=","} {print NF?NF-1:0}')
+fi
 NGPU2=${NGPUS}
 #--------------------
 START_DIM_MGPU=1024
@@ -71,6 +78,10 @@ do
     ./test_${p}symv_mgpu $g $UP $START_DIM_MGPU $STOP_DIM_MGPU $STEP_DIM_MGPU $OFFSET > ${RESDIR}/${p}symv${UP}_${g}gpu.txt
     echo " done"
   done
+done
+#----- HEMV-MGPU
+for (( g=$NGPU1; g <= $NGPUS && g<=$NGPU2; g++ ))
+do
   for p in c z
   do
     echo -n "testing ./test_${p}hemv_mgpu..."

--- a/kblas-test-l3-parallel.py
+++ b/kblas-test-l3-parallel.py
@@ -22,8 +22,17 @@ if (not os.path.isdir(BIN_PATH)):
     exit()
 
 #detect GPU devices
-cmd=('nvidia-smi -L | wc -l')
-NGPUS = int(commands.getstatusoutput(cmd)[1])
+NGPUS=0
+# first check using environment variable
+if ( "CUDA_VISIBLE_DEVICES" in os.environ ):
+    aux=os.environ["CUDA_VISIBLE_DEVICES"].strip(',')
+    if ( len(aux) > 0):
+      NGPUS=int( aux.count(',') ) + 1
+if ( NGPUS == 0 ):
+    # check using system
+    cmd=('nvidia-smi -L | wc -l')
+    NGPUS = int(commands.getstatusoutput(cmd)[1])
+
 if (NGPUS < 1):
     print 'Unable to detect an NVIDIA GPU device to test on! Exiting'
     exit()


### PR DESCRIPTION
Now we check for CUDA_VISIBLE_DEVICES to get the number of
available GPUS. This is necessary if the user wants to restrict to
specific GPUs.
If not set, use nvidia-smi